### PR TITLE
Updating npm version to match LTS/Node stable pairing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
       },
       "engines": {
         "node": "^18.16.0",
-        "npm": "^9.5.1"
+        "npm": "^9.5.1 || ^10.2.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": "^18.16.0",
-    "npm": "^9.5.1"
+    "npm": "^9.5.1 || ^10.2.5"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The current Internal node stable version includes an update to npm 10. Additionally, the .nvmrc file pins the LTS/hydrogen version - which too expects npm 10 as a pairing.

The change is backwards compatible and thus this should only be a minor bump.