### PR TITLE
ST-5444: Align engines config choice with backpack-web

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
       },
       "engines": {
         "node": "^18.16.0",
-        "npm": "^9.5.1 || ^10.2.5"
+        "npm": ">=9.5.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": "^18.16.0",
-    "npm": "^9.5.1 || ^10.2.5"
+    "npm": ">=9.5.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The engines config was previously widened to allow for Node 18 and NPM 10, introduced from Node 18.19.0.

It however was two patch versions too strict, as the lowest version of NPM 10 that comes in with Node 18.19.0 is 10.2.3.

This PR matches how we have backpack-web set up, using a `>=` to only limit to a minimum version but not a maximum, and setting that minimum starting in NPM 9.