### PR TITLE
[COPP-8605]: Add monitor step

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -7,7 +7,7 @@ defaults:
   run:
     shell: bash -l {0}
 
-env: 
+env:
   CACHE_NAME: node-modules-cache
   BUILD_CACHE_NAME: build-cache
 
@@ -19,15 +19,15 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           registry-url: 'https://registry.npmjs.org'
 
       - name: Restore Cache
-        uses: actions/cache/restore@v4.2.3
+        uses: actions/cache/restore@v5
         id: npm-cache
         with:
           path: |

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -19,6 +19,7 @@ jobs:
       pull-requests: write
 
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@b25f731bf2f9eb9748c2e9757d366c3e72fa2109 # v1.0.2-beta8
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@b25f731bf2f9eb9748c2e9757d366c3e72fa2109 # v1.0.2-beta8
       - uses: actions/create-github-app-token@v2
         id: app-token
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ defaults:
   run:
     shell: bash -l {0}
 
-env: 
+env:
   CACHE_NAME: node-modules-cache
   BUILD_CACHE_NAME: build-cache
 
@@ -20,15 +20,15 @@ jobs:
   Create-NPM-Cache:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upload to Cache
-        uses: actions/cache@v4.2.3
+        uses: actions/cache@v5
         id: npm-cache
         with:
           path: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
   Create-NPM-Cache:
     runs-on: ubuntu-latest
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@b25f731bf2f9eb9748c2e9757d366c3e72fa2109 # v1.0.2-beta8
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6
@@ -53,6 +54,7 @@ jobs:
       contents: write
       pull-requests: read
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@b25f731bf2f9eb9748c2e9757d366c3e72fa2109 # v1.0.2-beta8s
       - uses: actions/create-github-app-token@v2
         id: app-token
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,22 +12,22 @@ defaults:
   run:
     shell: bash -l {0}
 
-env: 
+env:
   CACHE_NAME: node-modules-cache
 
 jobs:
   Create-NPM-Cache:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upload to Cache
-        uses: actions/cache@v4.2.3
+        uses: actions/cache@v5
         id: npm-cache
         with:
           path: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,6 +19,7 @@ jobs:
   Create-NPM-Cache:
     runs-on: ubuntu-latest
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@b25f731bf2f9eb9748c2e9757d366c3e72fa2109 # v1.0.2-beta8
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
   Create-NPM-Cache:
     runs-on: ubuntu-latest
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@b25f731bf2f9eb9748c2e9757d366c3e72fa2109 # v1.0.2-beta8
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6
@@ -40,33 +41,34 @@ jobs:
     environment: Publishing
     needs: [Create-NPM-Cache]
     steps:
-    - name: Checkout source code
-      uses: actions/checkout@v6
-      with:
-        ref: main
+      - uses: GitHubSecurityLab/actions-permissions/monitor@b25f731bf2f9eb9748c2e9757d366c3e72fa2109 # v1.0.2-beta8
+      - name: Checkout source code
+        uses: actions/checkout@v6
+        with:
+          ref: main
 
-    - uses: actions/setup-node@v6
-      with:
-        node-version-file: ".nvmrc"
-        registry-url: 'https://registry.npmjs.org'
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: 'https://registry.npmjs.org'
 
-    - name: Restore Cache
-      uses: actions/cache/restore@v5
-      id: npm-cache
-      with:
-        path: |
-          node_modules/
-        key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json') }}
+      - name: Restore Cache
+        uses: actions/cache/restore@v5
+        id: npm-cache
+        with:
+          path: |
+            node_modules/
+          key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json') }}
 
-    - run: npm run build
+      - run: npm run build
 
-    - name: Confirm the build hasn't changed any files
-      run: ./check-pristine-state package-lock.json
+      - name: Confirm the build hasn't changed any files
+        run: ./check-pristine-state package-lock.json
 
-    - name: Publish NPM package
-      run: |
-        npm version $RELEASE_VERSION --no-git-tag-version
-        npm publish
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        RELEASE_VERSION: ${{ github.event.release.tag_name }}
+      - name: Publish NPM package
+        run: |
+          npm version $RELEASE_VERSION --no-git-tag-version
+          npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          RELEASE_VERSION: ${{ github.event.release.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,22 +8,22 @@ defaults:
   run:
     shell: bash -l {0}
 
-env: 
+env:
   CACHE_NAME: node-modules-cache
 
 jobs:
   Create-NPM-Cache:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upload to Cache
-        uses: actions/cache@v4.2.3
+        uses: actions/cache@v5
         id: npm-cache
         with:
           path: |
@@ -41,23 +41,23 @@ jobs:
     needs: [Create-NPM-Cache]
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: main
-    
-    - uses: actions/setup-node@v4
+
+    - uses: actions/setup-node@v6
       with:
         node-version-file: ".nvmrc"
         registry-url: 'https://registry.npmjs.org'
 
     - name: Restore Cache
-      uses: actions/cache/restore@v4.2.3
+      uses: actions/cache/restore@v5
       id: npm-cache
       with:
         path: |
           node_modules/
         key: ${{ env.CACHE_NAME }}-${{ hashFiles('package-lock.json') }}
-    
+
     - run: npm run build
 
     - name: Confirm the build hasn't changed any files


### PR DESCRIPTION
[COPP-8605](https://skyscanner.atlassian.net/browse/COPP-8605)
---
Adds (temporary, to be removed) permissions monitoring in order to verify appropriate permissions for a followup Zizmor PR.

See https://github.com/GitHubSecurityLab/actions-permissions for reference, the results can be viewed in the summary section of an actions run.

[COPP-8605]: https://skyscanner.atlassian.net/browse/COPP-8605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ